### PR TITLE
feat: add protection for develop branch in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,14 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Hook to prevent pushing to master branch
+# Hook to prevent pushing to protected branches
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-PROTECTED_BRANCH="master"
 
-if [ "$BRANCH" = "$PROTECTED_BRANCH" ]; then
-  echo "Direct push to $PROTECTED_BRANCH branch is not allowed."
-  echo "Please create a pull request instead."
-  exit 1
-fi 
+case "$BRANCH" in
+  "master"|"develop")
+    echo "🚫 Direct push to $BRANCH branch is not allowed."
+    echo "✨ Please create a feature branch and submit a pull request."
+    echo "   For feature branches use: feature/NOT-XXX-description"
+    exit 1
+    ;;
+esac 


### PR DESCRIPTION
This pull request updates the pre-push hook in `.husky/pre-push` to enhance protection against direct pushes to critical branches. The change extends the protection from just the `master` branch to include the `develop` branch as well, and improves the error messaging for better guidance.

Enhancements to pre-push hook:

* [`.husky/pre-push`](diffhunk://#diff-43bbc75a027a43baaddc57670d8ab49b4aa2981053c3cabba17567723d3a9fb6L4-R14): Updated the hook to prevent direct pushes to both `master` and `develop` branches, replacing the single branch check with a case statement. Improved error messages to include emoji and detailed instructions for creating feature branches.